### PR TITLE
Management Agent Install Keys

### DIFF
--- a/ociextirpater/config.py
+++ b/ociextirpater/config.py
@@ -50,6 +50,7 @@ class config:
     categories_to_delete =  [
                                 "cloudguard",
                                 "managementdashboard",
+                                "managementagent"
                                 "monitoring",
                                 "events",
                                 "notifications",

--- a/ociextirpater/ociclients/managementagent.py
+++ b/ociextirpater/ociclients/managementagent.py
@@ -1,0 +1,15 @@
+import oci
+from ociextirpater.OCIClient import OCIClient
+
+class managementagent( OCIClient ):
+    service_name = "Management Agent"
+    clientClass = oci.management_agent.ManagementAgentClient
+
+    objects = [
+        {
+            "function_list"    : "list_management_agent_install_keys",
+            "function_delete"  : "delete_management_agent_install_key",
+            "name_singular"    : "Management Install Key",
+            "name_plural"      : "Management Install Keys",
+        }
+    ]


### PR DESCRIPTION
Added class for managementagent - not sure if we need to de-install old agents because they are tied to compute, which may be deleted.  But this gets the install keys, which you can test by simply creating an install key in a compartment and then running 
```
python ociextirpate.py -cp <profile> -o managementagent -c <compartment ocid>
```
See if this is a valid add.