### PR TITLE
Fix and harden bootstrap.sh

### DIFF
--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -1,4 +1,9 @@
 
+# $TOBEDELETED required to be set
+if [ -v TOBEDELETED ]; then echo "#### Extirpate Compartment $TOBEDELETED ####"
+else echo "#### ERROR: No compartment set ####" && exit 1
+fi
+
 # Variables
 EXT_DIR=/usr/local/ociextirpater
 VENV=$EXT_DIR/.venv


### PR DESCRIPTION
Bootstrap would fail due to hanging branch command while cloning repository. While testing, found that the cloud-init script could fail due to yum operations running before repositories were available to the machine. Added a short delay to bootstrap to allow network operations to come online before execution, as well as basic retry logic for network operations in bootstrap.

Additionally, added appropriately permissioned extirpater user to run script rather than having root execute.