### PR TITLE
Add "Deploy to Oracle Cloud" Button

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,5 +1,7 @@
 # Deploy OCIExtirpater
 
+[![Deploy to Oracle Cloud](https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg)](https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://github.com/therealcmj/ociextirpater/releases/download/v1.6.7/deploy1.6.7.zip)
+
 ![OCI Extirpater Architecture (Basic)](./images/extirpater.png)
 
 ## Using Oracle Resource Manager


### PR DESCRIPTION
This PR updates the deploy/README.md to add a button to Deploy to Oracle Cloud. This button takes the user directly to OCI and Resource Manager to begin deploying the Extirpater as a stack.